### PR TITLE
Add docker runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,42 @@
 .PHONY: tests
+.DEFAULT_GOAL := usage
+
+export DEFAULT_PHP_VERSION = 5.6
+
+export EXEC := docker
+export PHP := $(DEFAULT_PHP_VERSION)
+
+# If shell executor and PHP not default, you cannot continue
+ifeq ($(EXEC),shell)
+ifneq ($(PHP),$(DEFAULT_PHP_VERSION),)
+   $(error "When using shell executor, PHP version depends on your host")
+endif
+endif
+
+ifeq ($(EXEC),docker)
+export PHP_RUN = docker run \
+	--rm --name kata-template -ti \
+	--volume ${PWD}:/app --workdir /app \
+	php:$(PHP)-alpine
+export COMPOSER_RUN = docker run \
+	--rm --name kata-template-composer -ti \
+	--volume ${PWD}\:/app \
+	--user $(id -u)\:$(id -g) composer
+else
+export PHP_RUN = ''
+export COMPOSER_RUN = ''
+endif
 
 install:
-	composer install
+	$(COMPOSER_RUN) composer install
 
 test tests:
-	./vendor/bin/phpunit --config=phpunit.xml
+	$(PHP_RUN) ./vendor/bin/phpunit --config=phpunit.xml
+
+help usage:
+	@echo 'Usage: make COMMAND [PHP=<version>] [EXEC=<docker|shell>]'
+	@echo
+	@echo 'Make variables:'
+	@echo '    PHP=<version>:      2 digits, dot separeted PHP version (5.6 by default)'
+	@echo '                        Incompatible with EXEC variable'
+	@echo '    EXEC=<executor>:    Runtime environment to run your make recipe'

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,22 @@ export PHP_RUN = ''
 export COMPOSER_RUN = ''
 endif
 
-install:
+install: ## Installs dependencies with Composer
 	$(COMPOSER_RUN) composer install
 
-test tests:
+test tests: ## Runs tests with PHPUnit
 	$(PHP_RUN) ./vendor/bin/phpunit --config=phpunit.xml
 
-help usage:
+help usage: ## Displays this help message
 	@echo 'Usage: make COMMAND [PHP=<version>] [EXEC=<docker|shell>]'
 	@echo
 	@echo 'Make variables:'
-	@echo '    PHP=<version>:      2 digits, dot separeted PHP version (5.6 by default)'
-	@echo '                        Incompatible with EXEC variable'
-	@echo '    EXEC=<executor>:    Runtime environment to run your make recipe'
+	@echo
+	@echo 'PHP             2 digits, dot separeted PHP version (5.6 by default)'
+	@echo '                    - Incompatible with EXEC variable'
+	@echo '                    - Exhaustive supported PHP version: https://hub.docker.com/_/php/'
+	@echo 'EXEC            Runtime environment to run your make recipe'
+	@echo
+	@echo 'Commands:'
+	@echo
+	@egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 22 -s ':#'

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@
 
 export DEFAULT_PHP_VERSION = 5.6
 
-export EXEC := docker
+export RUNTIME := docker
 export PHP := $(DEFAULT_PHP_VERSION)
 
-# If shell executor and PHP not default, you cannot continue
-ifeq ($(EXEC),shell)
+# If shell runtime and PHP not default, you cannot continue
+ifeq ($(RUNTIME),shell)
 ifneq ($(PHP),$(DEFAULT_PHP_VERSION),)
-   $(error "When using shell executor, PHP version depends on your host")
+   $(error "When using shell runtime, PHP version depends on your host")
 endif
 endif
 
-ifeq ($(EXEC),docker)
+ifeq ($(RUNTIME),docker)
 export PHP_RUN = docker run \
 	--rm --name kata-template -ti \
 	--volume ${PWD}:/app --workdir /app \
@@ -34,14 +34,14 @@ test tests: ## Runs tests with PHPUnit
 	$(PHP_RUN) ./vendor/bin/phpunit --config=phpunit.xml
 
 help usage: ## Displays this help message
-	@echo 'Usage: make COMMAND [PHP=<version>] [EXEC=<docker|shell>]'
+	@echo 'Usage: make COMMAND [PHP=<version>] [RUNTIME=<docker|shell>]'
 	@echo
 	@echo 'Make variables:'
 	@echo
 	@echo 'PHP             2 digits, dot separeted PHP version (5.6 by default)'
-	@echo '                    - Incompatible with EXEC variable'
+	@echo '                    - Incompatible with RUNTIME variable'
 	@echo '                    - Exhaustive supported PHP version: https://hub.docker.com/_/php/'
-	@echo 'EXEC            Runtime environment to run your make recipe'
+	@echo 'RUNTIME         Runtime environment to run your make recipe'
 	@echo
 	@echo 'Commands:'
 	@echo

--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ I come with this required via Composer:
 - `symfony/var-dumper`
 
 ### Make commands
-Make recipes work, by default, on PHP 5.6 with a docker runtime.
+My recipes work, by default, on PHP 5.6 with a docker runtime.
 
-Run `make help` to know how to change its runtime behaviour (no docker, version, etc.).
-
-#### Commands
-- `make install` to install dependencies with Composer
-- `make test` (or `make tests`) to run tests with PHPUnit
+Run `make help` to know:
+- how to change my `make` runtime behaviour (no docker, version, etc.)
+- get my available recipes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 👋 Hi.
 
 ### PHP version
-I'm currently working with `PHP 5.6`.
+I'm currently working, by default, with `PHP 5.6`.
 
 ### Packages
 I come with this required via Composer:
@@ -12,5 +12,10 @@ I come with this required via Composer:
 - `symfony/var-dumper`
 
 ### Make commands
+Make recipes work, by default, on PHP 5.6 with a docker runtime.
+
+Run `make help` to know how to change its runtime behaviour (no docker, version, etc.).
+
+#### Commands
 - `make install` to install dependencies with Composer
 - `make test` (or `make tests`) to run tests with PHPUnit


### PR DESCRIPTION
## Description

Run with docker in make targets.

### Adds
- `PHP` variable to choose PHP version
- `RUNTIME` to whether use docker or not

### Bonus
- Automagically generated documentation via `make help|usage`

### Some example

```bash
make tests PHP=7.1 # Docker runtime by default
make tests RUNTIME=shell
make tests PHP=7.1 RUNTIME=shell # Not possible, displays an error
```

## Caveats

The `Makefile` is starting to look ugly 😥 